### PR TITLE
feat: dynamic persona dropdown in dashboard + /api/personas/all endpoint

### DIFF
--- a/api.py
+++ b/api.py
@@ -1125,6 +1125,34 @@ def list_personas():
         log(f"Error listing personas: {traceback.format_exc()}")
         return jsonify({"error": str(e)}), 500
 
+@app.route('/api/personas/all', methods=['GET'])
+def list_all_typed_personas():
+    """List all personas with their types for the dashboard dropdown."""
+    update_activity()
+    
+    try:
+        from citizen_personas import get_personas
+        all_personas = get_personas()
+        
+        result = []
+        for key, persona in all_personas.items():
+            result.append({
+                "id": key,
+                "name": persona.name,
+                "emoji": persona.emoji,
+                "description": persona.description,
+                "type": persona.persona_type,
+            })
+        
+        return jsonify({
+            "success": True,
+            "personas": result,
+            "count": len(result)
+        })
+    except Exception as e:
+        log(f"Error listing all personas: {traceback.format_exc()}")
+        return jsonify({"error": str(e)}), 500
+
 @app.route('/api/personas/assistants', methods=['GET'])
 def list_assistant_personas():
     """List all available assistant-type personas for the llm_chat extension."""

--- a/static/swarm-dashboard.html
+++ b/static/swarm-dashboard.html
@@ -283,10 +283,7 @@
                 <div>
                     <label class="text-sm text-primary-500">Persona</label>
                     <select id="swarm-persona" class="w-full bg-primary-50 border border-primary-200 rounded px-3 py-2 mt-1 text-primary-900">
-                        <option value="compliant">Compliant</option>
-                        <option value="watchful">Watchful</option>
-                        <option value="exploiter">Exploiter</option>
-                        <option value="founder">Founder</option>
+                        <option value="">Loading personas...</option>
                     </select>
                 </div>
                 
@@ -701,9 +698,30 @@
         }
 
         // Swarm Modal
+        async function fetchPersonasForDropdown() {
+            const select = document.getElementById('swarm-persona');
+            try {
+                const res = await fetch(`${API_BASE}/api/personas/all`);
+                const data = await res.json();
+                if (data.success && data.personas) {
+                    select.innerHTML = '';
+                    data.personas.forEach(p => {
+                        const opt = document.createElement('option');
+                        opt.value = p.id;
+                        opt.textContent = `${p.emoji} ${p.name} (${p.type})`;
+                        select.appendChild(opt);
+                    });
+                }
+            } catch (e) {
+                console.error('Error fetching personas:', e);
+                select.innerHTML = '<option value="compliant">Compliant</option>';
+            }
+        }
+
         function openSwarmModal() {
             document.getElementById('swarm-modal').classList.remove('hidden');
             document.getElementById('swarm-result').classList.add('hidden');
+            fetchPersonasForDropdown();
         }
         function closeSwarmModal() {
             document.getElementById('swarm-modal').classList.add('hidden');


### PR DESCRIPTION
## Summary
The dashboard Swarm Management persona dropdown was hardcoded with only Compliant, Watchful, Exploiter, and Founder. Ashoka (assistant type) was missing.

### Changes
- Add `GET /api/personas/all` endpoint that returns all personas with their types
- Make dashboard persona dropdown dynamic — fetches from API on modal open
- Shows emoji + name + type for each persona (e.g. `🏛️ Ashoka (assistant)`)
- Falls back to Compliant if API fetch fails